### PR TITLE
String handling fixes for ESP32

### DIFF
--- a/src/rrule.cpp
+++ b/src/rrule.cpp
@@ -111,7 +111,7 @@ namespace uICAL {
                 index = 0;
             }
 
-            DateTime::Day day = this->parseDay(part.substr(part.length() - 2, string::npos));
+            DateTime::Day day = this->parseDay(part.substr(part.length() - 2, part.length()));
             array.push_back(Day_pair(index, day));
         });
         return array;

--- a/src/vevent.cpp
+++ b/src/vevent.cpp
@@ -23,7 +23,11 @@ namespace uICAL {
 
         this->summary = summary->value;
 
-        this->rrule = new_ptr<RRule>(rRule->value, this->start);
+        if (rRule == nullptr) {
+            this->rrule = new_ptr<RRule>(string::none(), this->start);
+        } else {
+            this->rrule = new_ptr<RRule>(rRule->value, this->start);
+        }
     }
 
     void VEvent::str(ostream& out) const {


### PR DESCRIPTION
Fixes to allow parsing to work on ESP32, all related to edge cases in string handling. Don't know if it's ESP32's string library not implementing the expected behavior, or this library using undefined behavior.

First is when RRULE is missing, it's a nullptr, but ESP32's string library doesn't handle string init from a nullptr (or nullptr + some offset).

Second is RRULE handling for nth weekday (e.g. `RRULE:FREQ=MONTHLY;UNTIL=[...];BYDAY=2WE`), it seems ESP32's string library doesn't like `npos`=`-1`.

Not tested on other platforms.