### PR TITLE
Fix arduino compilation errors

### DIFF
--- a/ARDUINO.md
+++ b/ARDUINO.md
@@ -1,3 +1,6 @@
 uICAL on Arduino  <!-- omit in toc -->
 ================
 
+The library uses C++ exceptions, which are typically disabled by Arduino IDE's compiler configurations. You need to edit the compiler flags and add the `-fexceptions` flag. 
+
+For example, for Arduino's `ESP8266` package, edit the `boards.txt` file found in `/packages/esp8266/hardware/esp8266/x.x.x/` where your Arduino installation places board files (on Mac it is in `~/Library/Arduino15/`). Edit the following line as follows: `generic.menu.exception.disabled.build.exception_flags=-fexceptions`

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -80,7 +80,7 @@ namespace uICAL {
         }
 
         bool istream_Stream::readuntil(string& st, char delim) {
-            size_t len = 81;
+            size_t len = 100;
             char buf[len];
 
             size_t read = this->stm.readBytesUntil(delim, buf, len-1);

--- a/src/uICAL/string.h
+++ b/src/uICAL/string.h
@@ -31,7 +31,6 @@ namespace uICAL {
                 string() : String() {}
                 string(const String& b) : String(b) {}
                 string(const char* st) : String(st) {}
-                string(const StringSumHelper& ssh) : String(ssh) {}
 
                 string substr(size_t from) const { return string(String::substring(from)); }
                 string substr(size_t from, size_t len) const { return string(String::substring(from, from + len)); }

--- a/src/vobjectstream.cpp
+++ b/src/vobjectstream.cpp
@@ -31,8 +31,7 @@ namespace uICAL {
         VLine_ptr line = this->stm.next();
 
         if (!line) {
-            log_error("Parse error: %s", "Empty stream");
-            throw ParseError(string("Parse error, empty stream"));
+            return string::none();
         }
         if (line->name == "END") {
             log_trace("Final component: %s", line->as_str().c_str());


### PR DESCRIPTION
This fixes #16. 

More precisely:

1. Removes the unused `StringSumHelper` constructor in `string.h`
2. Adds documentation on how to build with the Arduino IDE

It also fixes the following bugs
1. The buffer in `istream_Stream::readuntil` is too small for some WebDAV implementations
2. Fixes `VObjectStream` exception when the input, as a list of VObjects, isn't wrapped in `BEGIN/END VCALENDAR`. This is the case for some `CardDAV` queries. Now it simply ends the stream if the input ends as well. 