### PR TITLE
Fix Arduino corrupted multiline fields

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -52,7 +52,9 @@ namespace uICAL {
         }
 
         void string::rtrim() {
-            this->trim();
+            while (!this->empty() && std::isspace(this->charAt(this->length() - 1))) {
+                this->remove(this->length() - 1);
+            }
         }
 
     #else


### PR DESCRIPTION
## Summary
`string::rtrim` are not functionally equivalent and result in missing characters in multiline fields. 

## Problem 
The Arduino implementation trimmed space from both the beginning and end of a string, whereas the standard correctly implemented a `rtrim` and only removed spaces from the end of a string.

## Solution
This change updates the Arduino implementation of `string::rtrim` to only remove spaces at the end of a string.

## Test Plan
- [x] `./de make test-all` passes completely
- [x] Manually validated changes on an ESP32-WROOM device